### PR TITLE
feat: snappy

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,4 @@
+AccessKeyId=minioadmin
+AccessKeySecret=minioadmin
+Endpoint=http://127.0.0.1:9000
+Bucket=test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/*
 .env*
+!.env-example

--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
-AWOS: Wrapper For Aliyun OSS And Amazon S3
-====
+# AWOS: Wrapper For Aliyun OSS And Amazon S3
 
 [![](https://img.shields.io/badge/version-2.0.0-brightgreen.svg)](https://github.com/shimohq/awos)
 
-awos for node:  https://github.com/shimohq/awos-js
+awos for node: https://github.com/shimohq/awos-js
 
 ## feat
 
 - enable shards bucket
 - add retry strategy
 - avoid 404 status code:
-    - `Get(objectName string) (string, error)` will return `"", nil` when object not exist
-    - `Head(key string, meta []string) (map[string]string, error)` will return `nil, nil` when object not exist
+  - `Get(objectName string) (string, error)` will return `"", nil` when object not exist
+  - `Head(key string, meta []string) (map[string]string, error)` will return `nil, nil` when object not exist
 
 ## installing
 
@@ -70,9 +69,7 @@ DelMulti(keys []string) error
 Head(key string, meta []string) (map[string]string, error)
 ListObject(key string, prefix string, marker string, maxKeys int, delimiter string) ([]string, error)
 SignURL(key string, expired int64) (string, error)
+GetAndDecompress(key string) (string, error)
+GetAndDecompressAsReader(key string) (io.ReadCloser, error)
+CompressAndPut(key string, reader io.ReadSeeker, meta map[string]string, options ...PutOptions) error
 ```
-
-
-
-
-

--- a/aws.go
+++ b/aws.go
@@ -139,7 +139,8 @@ func (a *AWS) GetAndDecompressAsReader(key string) (io.ReadCloser, error) {
 		body := result.Body
 
 		reader := snappy.NewReader(body)
-		return ioutil.NopCloser(reader), nil
+
+		return CombinedReadCloser{ReadCloser: body, Reader: reader}, nil
 	}
 
 	return result.Body, nil

--- a/client.go
+++ b/client.go
@@ -2,13 +2,14 @@ package awos
 
 import (
 	"errors"
+	"io"
+	"strings"
+
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"io"
-	"strings"
 )
 
 type Client interface {
@@ -20,6 +21,9 @@ type Client interface {
 	Head(key string, meta []string) (map[string]string, error)
 	ListObject(key string, prefix string, marker string, maxKeys int, delimiter string) ([]string, error)
 	SignURL(key string, expired int64) (string, error)
+	GetAndDecompress(key string) (string, error)
+	GetAndDecompressAsReader(key string) (io.ReadCloser, error)
+	CompressAndPut(key string, reader io.ReadSeeker, meta map[string]string, options ...PutOptions) error
 }
 
 type Options struct {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.29.8
 	github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/golang/snappy v0.0.2
 	github.com/google/uuid v1.1.1
 	github.com/joho/godotenv v1.3.0
 	github.com/kr/pretty v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/golang/net v0.0.0-20190213061140-3a22650c66bd h1:csDe9bk66ilRldyDxPBPKfQJwPd11g7Fgj6/fW5+Xxg=
 github.com/golang/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:98y8FxUyMjTdJ5eOj/8vzuiVO14/dkJ98NYhEPG8QGY=
+github.com/golang/snappy v0.0.2 h1:aeE13tS0IiQgFjYdoL8qN3K1N2bXXtI6Vi51/y7BpMw=
+github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=

--- a/oss.go
+++ b/oss.go
@@ -130,7 +130,7 @@ func (ossClient *OSS) GetAndDecompressAsReader(key string) (io.ReadCloser, error
 
 		reader := snappy.NewReader(body)
 
-		return ioutil.NopCloser(reader), nil
+		return CombinedReadCloser{ReadCloser: body, Reader: reader}, nil
 	}
 
 	return body, nil

--- a/oss.go
+++ b/oss.go
@@ -1,13 +1,16 @@
 package awos
 
 import (
+	"bytes"
 	"errors"
-	"github.com/aliyun/aliyun-oss-go-sdk/oss"
-	"github.com/avast/retry-go"
 	"io"
 	"io/ioutil"
 	"strings"
 	"time"
+
+	"github.com/aliyun/aliyun-oss-go-sdk/oss"
+	"github.com/avast/retry-go"
+	"github.com/golang/snappy"
 )
 
 type OSS struct {
@@ -40,25 +43,62 @@ func (ossClient *OSS) GetAsReader(key string) (io.ReadCloser, error) {
 }
 
 func (ossClient *OSS) Get(key string) (string, error) {
-	bucket, err := ossClient.getBucket(key)
+	result, err := ossClient.get(key)
+
 	if err != nil {
 		return "", err
 	}
 
-	body, err := bucket.GetObject(key)
+	if result == nil {
+		return "", nil
+	}
+
+	body := result.Response
 	defer func() {
 		if body != nil {
 			body.Close()
 		}
 	}()
 
+	data, err := ioutil.ReadAll(body)
 	if err != nil {
-		if oerr, ok := err.(oss.ServiceError); ok {
-			if oerr.StatusCode == 404 {
-				return "", nil
-			}
-		}
 		return "", err
+	}
+
+	return string(data), nil
+}
+
+func (ossClient *OSS) GetAndDecompress(key string) (string, error) {
+	result, err := ossClient.get(key)
+
+	if err != nil {
+		return "", err
+	}
+
+	if result == nil {
+		return "", nil
+	}
+
+	body := result.Response
+	defer func() {
+		if body != nil {
+			body.Close()
+		}
+	}()
+
+	compressor := body.Headers.Get("X-Oss-Meta-Compressor")
+	if compressor != "" {
+		if compressor != "snappy" {
+			return "", errors.New("GetAndDecompress only supports snappy for now, got " + compressor)
+		}
+
+		reader := snappy.NewReader(body)
+		data, err := ioutil.ReadAll(reader)
+
+		if err != nil {
+			return "", err
+		}
+		return string(data), err
 	}
 
 	data, err := ioutil.ReadAll(body)
@@ -67,6 +107,53 @@ func (ossClient *OSS) Get(key string) (string, error) {
 	}
 
 	return string(data), nil
+}
+
+func (ossClient *OSS) GetAndDecompressAsReader(key string) (io.ReadCloser, error) {
+	result, err := ossClient.get(key)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if result == nil {
+		return nil, nil
+	}
+
+	body := result.Response
+
+	compressor := body.Headers.Get("X-Oss-Meta-Compressor")
+	if compressor != "" {
+		if compressor != "snappy" {
+			return nil, errors.New("GetAndDecompress only supports snappy for now, got " + compressor)
+		}
+
+		reader := snappy.NewReader(body)
+
+		return ioutil.NopCloser(reader), nil
+	}
+
+	return body, nil
+}
+
+func (ossClient *OSS) get(key string) (*oss.GetObjectResult, error) {
+	bucket, err := ossClient.getBucket(key)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := bucket.DoGetObject(&oss.GetObjectRequest{ObjectKey: key}, []oss.Option{})
+
+	if err != nil {
+		if oerr, ok := err.(oss.ServiceError); ok {
+			if oerr.StatusCode == 404 {
+				return nil, nil
+			}
+		}
+		return nil, err
+	}
+
+	return result, nil
 }
 
 func (ossClient *OSS) Put(key string, reader io.ReadSeeker, meta map[string]string, options ...PutOptions) error {
@@ -97,6 +184,22 @@ func (ossClient *OSS) Put(key string, reader io.ReadSeeker, meta map[string]stri
 		}
 		return err
 	}, retry.Attempts(3), retry.Delay(1*time.Second))
+}
+
+func (ossClient *OSS) CompressAndPut(key string, reader io.ReadSeeker, meta map[string]string, options ...PutOptions) error {
+	data, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return err
+	}
+
+	var buf bytes.Buffer
+	writer := snappy.NewBufferedWriter(&buf)
+	writer.Write(data)
+	writer.Flush()
+	writer.Close()
+	meta["Compressor"] = "snappy"
+
+	return ossClient.Put(key, bytes.NewReader(buf.Bytes()), meta, options...)
 }
 
 func (ossClient *OSS) Del(key string) error {

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,19 @@
+package awos
+
+import "io"
+
+// CombinedReadCloser combined a ReadCloser and a Readers to a new ReaderCloser
+// which will read from reader and close origin closer
+type CombinedReadCloser struct {
+	ReadCloser io.ReadCloser
+	Reader     io.Reader
+}
+
+func (combined CombinedReadCloser) Read(b []byte) (int, error) {
+	return combined.Reader.Read(b)
+}
+
+// Close origin ReaderCloser
+func (combined CombinedReadCloser) Close() error {
+	return combined.ReadCloser.Close()
+}


### PR DESCRIPTION
snappy 的支持，实现了 GetAndDecompress、GetAndDecompressAsReader、CompressAndPut 三个方法。

有个问题，没想好最佳的办法：
```
if compressor != nil {
		if *compressor != "snappy" {
			return nil, errors.New("GetAndDecompress only supports snappy for now, got " + *compressor)
		}

		body := result.Body

		reader := snappy.NewReader(body)
		return ioutil.NopCloser(reader), nil
	}
```
这里会有原来的 ReadCloser 未抛出的情况（没地方 Close 了），可以讨论下最佳实践。