### PR TITLE
feat: add support to presign URLs using a different endpoint and AWS-…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea/*
+
+dev/
+
 .env*
 !.env-example

--- a/README.md
+++ b/README.md
@@ -25,25 +25,38 @@ import "github.com/shimohq/awos/v3"
 
 awsClient, err := awos.New(&awos.Options{
     // Required, value is one of oss/s3, case insensetive
-    StorageType: "string"
+    StorageType: "string",
     // Required
-    AccessKeyID: "string"
+    AccessKeyID: "string",
     // Required
-    AccessKeySecret: "string"
+    AccessKeySecret: "string",
+    // Required if it's s3-like
+    Endpoint: "string",
     // Required
-    Endpoint: "string"
-    // Required
-    Bucket: "string"
+    Bucket: "string",
     // Optional, choose which bucket to use based on the last character of the key,
     // if bucket is 'content', shards is ['abc', 'edf'],
     // then the last character of the key with a/b/c will automatically use the content-abc bucket, and vice versa
-    Shards: [2]string{"abc","def"}
+    Shards: [2]string{"abc","def"},
     // Only for s3-like
-    Region: "string"
+    Region: "string",
     // Only for s3-like, whether to force path style URLs for S3 objects.
-    S3ForcePathStyle: false
+    S3ForcePathStyle: false,
     // Only for s3-like
-    SSL: false
+    SSL: false,
+    // Only for s3-like, for presign URLs in different settings
+    Sign: &awos.SignOptions{
+      // Only for s3-like, you can assign a different endpoint for presign.
+      // default is the same as `Endpoint`
+      Endpoint: "string",
+      Region: "string",
+      SSL: true,
+      // Only for s3-like, assign the AWS-Signature-Version that you like to use,
+      // this can only be either `v4` or `v2`.
+      //
+      // default is `v4`
+      SignVersion: "v2",
+    },
 })
 ```
 

--- a/aws/s3v2/signer.go
+++ b/aws/s3v2/signer.go
@@ -1,0 +1,312 @@
+/**
+ * This provide compability for some old S3-compatible implementations.
+ *
+ * Lots of code is copied from [minio-go](https://github.com/minio/minio-go).
+ */
+
+package s3v2
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+// SignRequestHandler is a named request handler the SDK will use to sign
+// service client request with using the V4 signature.
+var SignRequestHandler = request.NamedHandler{
+	Name: "s3v2.SignRequestHandler", Fn: PreSignRequest,
+}
+
+var (
+	errNotAPresignRequest = errors.New("S3V2 signer is only for presigning GET URLs")
+)
+
+type signer struct {
+	// Values that must be populated from the request
+	Request     *http.Request
+	Time        time.Time
+	Expires     time.Duration
+	Credentials *credentials.Credentials
+	Debug       aws.LogLevelType
+	Logger      aws.Logger
+
+	Query        url.Values
+	stringToSign string
+	signature    string
+}
+
+func (v2 *signer) Sign() error {
+	credValue, err := v2.Credentials.Get()
+	if err != nil {
+		return err
+	}
+
+	v2.Query = v2.Request.URL.Query()
+
+	accessKeyID := credValue.AccessKeyID
+	secretAccessKey := credValue.SecretAccessKey
+
+	epochExpires := v2.Time.Unix() + int64(v2.Expires.Seconds())
+
+	// Add expires header if not present.
+	if expiresStr := v2.Request.Header.Get("Expires"); expiresStr == "" {
+		v2.Request.Header.Set("Expires", strconv.FormatInt(epochExpires, 10))
+	}
+
+	query := v2.Query
+	query.Set("AWSAccessKeyId", accessKeyID)
+
+	// Fill in Expires for presigned query.
+	query.Set("Expires", strconv.FormatInt(epochExpires, 10))
+
+	// Get presigned string to sign.
+	v2.stringToSign = preStringToSignV2(*v2.Request)
+	hm := hmac.New(sha1.New, []byte(secretAccessKey))
+	hm.Write([]byte(v2.stringToSign))
+
+	// Calculate signature.
+	v2.signature = base64.StdEncoding.EncodeToString(hm.Sum(nil))
+	query.Set("Signature", v2.signature)
+
+	if v2.Debug.Matches(aws.LogDebugWithSigning) {
+		v2.logSigningInfo()
+	}
+
+	return nil
+}
+
+const logSignInfoMsg = `DEBUG: Request Signature:
+---[ STRING TO SIGN ]--------------------------------
+%s
+---[ SIGNATURE ]-------------------------------------
+%s
+-----------------------------------------------------`
+
+func (v2 *signer) logSigningInfo() {
+	msg := fmt.Sprintf(logSignInfoMsg, v2.stringToSign, v2.Query.Get("Signature"))
+	v2.Logger.Log(msg)
+}
+
+func PreSignRequest(req *request.Request) {
+	// If the request does not need to be signed ignore the signing of the
+	// request if the AnonymousCredentials object is used.
+	if req.Config.Credentials == credentials.AnonymousCredentials {
+		return
+	}
+
+	if req.HTTPRequest.Method != "GET" || req.ExpireTime == 0 {
+		req.Error = errNotAPresignRequest
+		return
+	}
+
+	v2 := signer{
+		Request:     req.HTTPRequest,
+		Time:        req.Time,
+		Expires:     req.ExpireTime,
+		Credentials: req.Config.Credentials,
+		Debug:       req.Config.LogLevel.Value(),
+		Logger:      req.Config.Logger,
+	}
+
+	req.Error = v2.Sign()
+
+	if req.Error != nil {
+		return
+	}
+
+	v2.Request.URL.RawQuery = v2.Query.Encode()
+}
+
+// From the Amazon docs:
+//
+// StringToSign = HTTP-Verb + "\n" +
+// 	 Content-Md5 + "\n" +
+//	 Content-Type + "\n" +
+//	 Expires + "\n" +
+//	 CanonicalizedProtocolHeaders +
+//	 CanonicalizedResource;
+func preStringToSignV2(req http.Request) string {
+	buf := new(bytes.Buffer)
+	// Write standard headers.
+	writePreSignV2Headers(buf, req)
+	// Write canonicalized protocol headers if any.
+	writeCanonicalizedHeaders(buf, req)
+	// Write canonicalized Query resources if any.
+	writeCanonicalizedResource(buf, req)
+	return buf.String()
+}
+
+// writePreSignV2Headers - write preSign v2 required headers.
+func writePreSignV2Headers(buf *bytes.Buffer, req http.Request) {
+	buf.WriteString(req.Method + "\n")
+	buf.WriteString(req.Header.Get("Content-Md5") + "\n")
+	buf.WriteString(req.Header.Get("Content-Type") + "\n")
+	buf.WriteString(req.Header.Get("Expires") + "\n")
+}
+
+// writeCanonicalizedHeaders - write canonicalized headers.
+func writeCanonicalizedHeaders(buf *bytes.Buffer, req http.Request) {
+	var protoHeaders []string
+	vals := make(map[string][]string)
+	for k, vv := range req.Header {
+		// All the AMZ headers should be lowercase
+		lk := strings.ToLower(k)
+		if strings.HasPrefix(lk, "x-amz") {
+			protoHeaders = append(protoHeaders, lk)
+			vals[lk] = vv
+		}
+	}
+	sort.Strings(protoHeaders)
+	for _, k := range protoHeaders {
+		buf.WriteString(k)
+		buf.WriteByte(':')
+		for idx, v := range vals[k] {
+			if idx > 0 {
+				buf.WriteByte(',')
+			}
+			if strings.Contains(v, "\n") {
+				// TODO: "Unfold" long headers that
+				// span multiple lines (as allowed by
+				// RFC 2616, section 4.2) by replacing
+				// the folding white-space (including
+				// new-line) by a single space.
+				buf.WriteString(v)
+			} else {
+				buf.WriteString(v)
+			}
+		}
+		buf.WriteByte('\n')
+	}
+}
+
+// AWS S3 Signature V2 calculation rule is give here:
+// http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html#RESTAuthenticationStringToSign
+
+// Whitelist resource list that will be used in query string for signature-V2 calculation.
+// The list should be alphabetically sorted
+var resourceList = []string{
+	"acl",
+	"delete",
+	"lifecycle",
+	"location",
+	"logging",
+	"notification",
+	"partNumber",
+	"policy",
+	"replication",
+	"requestPayment",
+	"response-cache-control",
+	"response-content-disposition",
+	"response-content-encoding",
+	"response-content-language",
+	"response-content-type",
+	"response-expires",
+	"torrent",
+	"uploadId",
+	"uploads",
+	"versionId",
+	"versioning",
+	"versions",
+	"website",
+}
+
+// From the Amazon docs:
+//
+// CanonicalizedResource = [ "/" + Bucket ] +
+// 	  <HTTP-Request-URI, from the protocol name up to the query string> +
+// 	  [ sub-resource, if present. For example "?acl", "?location", "?logging", or "?torrent"];
+func writeCanonicalizedResource(buf *bytes.Buffer, req http.Request) {
+	// Save request URL.
+	requestURL := req.URL
+	// Get encoded URL path.
+	buf.WriteString(encodeURL2Path(&req))
+	if requestURL.RawQuery != "" {
+		var n int
+		vals, _ := url.ParseQuery(requestURL.RawQuery)
+		// Verify if any sub resource queries are present, if yes
+		// canonicallize them.
+		for _, resource := range resourceList {
+			if vv, ok := vals[resource]; ok && len(vv) > 0 {
+				n++
+				// First element
+				switch n {
+				case 1:
+					buf.WriteByte('?')
+				// The rest
+				default:
+					buf.WriteByte('&')
+				}
+				buf.WriteString(resource)
+				// Request parameters
+				if len(vv[0]) > 0 {
+					buf.WriteByte('=')
+					buf.WriteString(vv[0])
+				}
+			}
+		}
+	}
+}
+
+// Encode input URL path to URL encoded path.
+func encodeURL2Path(req *http.Request) (path string) {
+	path = encodePath(req.URL.Path)
+	return
+}
+
+// if object matches reserved string, no need to encode them
+var reservedObjectNames = regexp.MustCompile("^[a-zA-Z0-9-_.~/]+$")
+
+// encodePath encode the strings from UTF-8 byte representations to HTML hex escape sequences
+//
+// This is necessary since regular url.Parse() and url.Encode() functions do not support UTF-8
+// non english characters cannot be parsed due to the nature in which url.Encode() is written
+//
+// This function on the other hand is a direct replacement for url.Encode() technique to support
+// pretty much every UTF-8 character.
+func encodePath(pathName string) string {
+	if reservedObjectNames.MatchString(pathName) {
+		return pathName
+	}
+	var encodedPathname strings.Builder
+	for _, s := range pathName {
+		if 'A' <= s && s <= 'Z' || 'a' <= s && s <= 'z' || '0' <= s && s <= '9' { // §2.3 Unreserved characters (mark)
+			encodedPathname.WriteRune(s)
+			continue
+		}
+		switch s {
+		case '-', '_', '.', '~', '/': // §2.3 Unreserved characters (mark)
+			encodedPathname.WriteRune(s)
+			continue
+		default:
+			len := utf8.RuneLen(s)
+			if len < 0 {
+				// if utf8 cannot convert return the same string as is
+				return pathName
+			}
+			u := make([]byte, len)
+			utf8.EncodeRune(u, s)
+			for _, r := range u {
+				hex := hex.EncodeToString([]byte{r})
+				encodedPathname.WriteString("%" + strings.ToUpper(hex))
+			}
+		}
+	}
+	return encodedPathname.String()
+}

--- a/aws/s3v2/signer_test.go
+++ b/aws/s3v2/signer_test.go
@@ -1,0 +1,124 @@
+package s3v2
+
+import (
+	"net/http"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/awstesting"
+)
+
+// Tests for 'func TestResourceListSorting(t *testing.T)'.
+func TestResourceListSorting(t *testing.T) {
+	sortedResourceList := make([]string, len(resourceList))
+	copy(sortedResourceList, resourceList)
+	sort.Strings(sortedResourceList)
+	for i := 0; i < len(resourceList); i++ {
+		if resourceList[i] != sortedResourceList[i] {
+			t.Errorf("Expected resourceList[%d] = \"%s\", resourceList is not correctly sorted.", i, sortedResourceList[i])
+			break
+		}
+	}
+}
+
+func TestPreSignRequest(t *testing.T) {
+	var testCases = []struct {
+		endpointURL       string
+		accessKeyID       string
+		secretAccessKey   string
+		sessionToken      string
+		signTime          time.Time
+		expires           time.Duration
+		path              string
+		expectedExpires   string
+		expectedSignature string
+	}{
+		{
+			endpointURL:       "https://s3v2-compatible.com/",
+			accessKeyID:       "AKID",
+			secretAccessKey:   "SECRET",
+			sessionToken:      "SESSION",
+			signTime:          time.Unix(1621836642, 0),
+			expires:           1 * time.Minute,
+			path:              "/awostest/test123",
+			expectedExpires:   "1621836702",
+			expectedSignature: "aIShchTjP5Ly7bH0NtX+3yXtPjU=",
+		},
+	}
+
+	for _, testCase := range testCases {
+		creds := credentials.NewStaticCredentials(
+			testCase.accessKeyID,
+			testCase.secretAccessKey,
+			testCase.sessionToken,
+		)
+
+		svc := awstesting.NewClient(&aws.Config{
+			Credentials: creds,
+			Region:      aws.String("cn-north-1"),
+		})
+
+		req := svc.NewRequest(
+			&request.Operation{
+				Name:       "OpName",
+				HTTPMethod: http.MethodGet,
+				HTTPPath:   testCase.path,
+			},
+			nil,
+			nil,
+		)
+		req.Time = testCase.signTime
+		req.ExpireTime = testCase.expires
+
+		PreSignRequest(req)
+		if req.Error != nil {
+			t.Fatalf("expect no error, got %v", req.Error)
+		}
+
+		reqQuery := req.HTTPRequest.URL.Query()
+
+		if e, a := 3, len(reqQuery); e != a {
+			t.Errorf("expect %v, got %v", e, a)
+		}
+		if e, a := testCase.accessKeyID, reqQuery.Get("AWSAccessKeyId"); e != a {
+			t.Errorf("expect %v, got %v", e, a)
+		}
+		if e, a := testCase.expectedExpires, reqQuery.Get("Expires"); e != a {
+			t.Errorf("expect %v, got %v", e, a)
+		}
+		if e, a := testCase.expectedSignature, reqQuery.Get("Signature"); e != a {
+			t.Errorf("expect %v, got %v", e, a)
+		}
+	}
+
+}
+
+// Tests validate the URL path encoder.
+func TestEncodePath(t *testing.T) {
+	testCases := []struct {
+		// Input.
+		inputStr string
+		// Expected result.
+		result string
+	}{
+		{"thisisthe%url", "thisisthe%25url"},
+		{"本語", "%E6%9C%AC%E8%AA%9E"},
+		{"本語.1", "%E6%9C%AC%E8%AA%9E.1"},
+		{">123", "%3E123"},
+		{"myurl#link", "myurl%23link"},
+		{"space in url", "space%20in%20url"},
+		{"url+path", "url%2Bpath"},
+		{"url/path", "url/path"},
+	}
+
+	for i, testCase := range testCases {
+		result := encodePath(testCase.inputStr)
+		if testCase.result != result {
+			t.Errorf("Test %d: Expected queryEncode result to be \"%s\", but found it to be \"%s\" instead", i+1, testCase.result, result)
+		}
+	}
+}

--- a/client.go
+++ b/client.go
@@ -6,10 +6,6 @@ import (
 	"strings"
 
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/s3"
 )
 
 // Client interface
@@ -27,6 +23,14 @@ type Client interface {
 	GetAndDecompressAsReader(key string) (io.ReadCloser, error)
 	CompressAndPut(key string, reader io.ReadSeeker, meta map[string]string, options ...PutOptions) error
 	Range(key string, offset int64, length int64) (io.ReadCloser, error)
+}
+
+type SignOptions struct {
+	Endpoint string
+	Region   string
+	SSL      bool
+	// `v4` or `v2`, default: `v4`
+	SignVersion string
 }
 
 // Options for New method
@@ -51,6 +55,16 @@ type Options struct {
 	S3ForcePathStyle bool
 	// Only for s3-like
 	SSL bool
+	// Only for s3-like
+	Sign *SignOptions
+}
+
+func (o *Options) IsS3Like() bool {
+	return o.S3ForcePathStyle
+}
+
+func (o *Options) HasSignOptions() bool {
+	return o.Sign != nil
 }
 
 // New awos Client instance
@@ -92,46 +106,7 @@ func New(options *Options) (Client, error) {
 
 		return ossClient, nil
 	} else if storageType == "s3" {
-		var sess *session.Session
-
-		// use minio
-		if options.S3ForcePathStyle {
-			sess = session.Must(session.NewSession(&aws.Config{
-				Region:           aws.String(options.Region),
-				DisableSSL:       aws.Bool(!options.SSL),
-				Credentials:      credentials.NewStaticCredentials(options.AccessKeyID, options.AccessKeySecret, ""),
-				Endpoint:         aws.String(options.Endpoint),
-				S3ForcePathStyle: aws.Bool(true),
-			}))
-		} else {
-			sess = session.Must(session.NewSession(&aws.Config{
-				Region:      aws.String(options.Region),
-				DisableSSL:  aws.Bool(!options.SSL),
-				Credentials: credentials.NewStaticCredentials(options.AccessKeyID, options.AccessKeySecret, ""),
-			}))
-		}
-		service := s3.New(sess)
-
-		var s3Client *S3
-		if options.Shards != nil && len(options.Shards) > 0 {
-			buckets := make(map[string]string)
-			for _, v := range options.Shards {
-				for i := 0; i < len(v); i++ {
-					buckets[strings.ToLower(v[i:i+1])] = options.Bucket + "-" + v
-				}
-			}
-			s3Client = &S3{
-				ShardsBucket: buckets,
-				Client:       service,
-			}
-		} else {
-			s3Client = &S3{
-				BucketName: options.Bucket,
-				Client:     service,
-			}
-		}
-
-		return s3Client, nil
+		return newS3(options)
 	} else {
 		return nil, fmt.Errorf("Unknown StorageType:\"%s\", only supports oss,s3", options.StorageType)
 	}


### PR DESCRIPTION
PR 目的：

- 允许使用不同的 Endpoint（等配置）来 presign URLs：部分 S3-like 需要对外返回另一个域名的链接
- 增加 AWS-SigV2 的签名方法：用于兼容某些仅支持 SigV2 的 S3-like 实现
