### PR TITLE
feat: add support to assign an endpoint for AWS S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea/*
 .env*
 !.env-example
+
+dev/

--- a/client.go
+++ b/client.go
@@ -104,11 +104,15 @@ func New(options *Options) (Client, error) {
 				S3ForcePathStyle: aws.Bool(true),
 			}))
 		} else {
-			sess = session.Must(session.NewSession(&aws.Config{
+			config := &aws.Config{
 				Region:      aws.String(options.Region),
 				DisableSSL:  aws.Bool(!options.SSL),
 				Credentials: credentials.NewStaticCredentials(options.AccessKeyID, options.AccessKeySecret, ""),
-			}))
+			}
+			if options.Endpoint != "" {
+				config.Endpoint = aws.String(options.Endpoint)
+			}
+			sess = session.Must(session.NewSession(config))
 		}
 		service := s3.New(sess)
 


### PR DESCRIPTION
配合 [AWS VPC Endpoint](https://github.com/aws/aws-sdk-go-v2/blob/b7d8e15425d2f86a0596e8d7db2e33bf382a21dd/example/service/s3/usingPrivateLink/README.md) 使用的时候需要指定 endpoint 字段。