### PR TITLE
chore: upgrade snappy version

### DIFF
--- a/client.go
+++ b/client.go
@@ -67,7 +67,7 @@ const (
 func New(options *Options) (Client, error) {
 	storageType := strings.ToLower(options.StorageType)
 
-	if storageType == "oss" {
+	if storageType == StorageTypeOSS {
 		client, err := oss.New(options.Endpoint, options.AccessKeyID, options.AccessKeySecret)
 		if err != nil {
 			return nil, err
@@ -101,7 +101,7 @@ func New(options *Options) (Client, error) {
 		}
 
 		return ossClient, nil
-	} else if storageType == "s3" {
+	} else if storageType == StorageTypeS3 {
 		var config *aws.Config
 
 		// use minio

--- a/constants.go
+++ b/constants.go
@@ -1,0 +1,8 @@
+package awos
+
+const (
+	StorageTypeOSS = "oss"
+	StorageTypeS3  = "s3"
+
+	MetaCompressor = "compressor"
+)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.38.52
 	github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/golang/snappy v0.0.2
+	github.com/golang/snappy v0.0.4
 	github.com/joho/godotenv v1.3.0
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/satori/go.uuid v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/golang/net v0.0.0-20190213061140-3a22650c66bd h1:csDe9bk66ilRldyDxPBP
 github.com/golang/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:98y8FxUyMjTdJ5eOj/8vzuiVO14/dkJ98NYhEPG8QGY=
 github.com/golang/snappy v0.0.2 h1:aeE13tS0IiQgFjYdoL8qN3K1N2bXXtI6Vi51/y7BpMw=
 github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
+github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=


### PR DESCRIPTION
1. 升级 snappy -> 0.0.4，解决 ARM64 snappy 压缩的报错
2. 暴露常量